### PR TITLE
Test dependencies by themselves first

### DIFF
--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -24,7 +24,6 @@ start_spinner
 suppress build_bzip2
 suppress build_openssl
 suppress build_libpng
-suppress build_libwebp
 suppress build_szip
 suppress build_swig
 # We need to find a failable test for build_github
@@ -38,9 +37,10 @@ suppress build_swig
     )
 suppress build_flex
 suppress build_openblas
-suppress build_tiff
-suppress build_lcms2
 suppress ensure_xz
+suppress build_tiff
+suppress build_libwebp
+suppress build_lcms2
 suppress build_freetype
 suppress build_libyaml
 if [ -z "$IS_OSX" ]; then


### PR DESCRIPTION
`ensure_xz` is a dependency of `build_tiff`
https://github.com/matthew-brett/multibuild/blob/c395b10e8395d43b51209760dc0853303ecfcd9e/library_builders.sh#L148-L153

However, `build_tiff` is currently tested before `ensure_xz`. So if `ensure_xz` were to fail, it would appear as part of the `build_tiff` test, rather than failing on it's own.

Similarly, `build_tiff` is a dependency of `build_libwebp`
https://github.com/matthew-brett/multibuild/blob/4e24f8228277dd7398d95bf43e2cb6eb7eb1f029/library_builders.sh#L197-L204

Yet `build_libwebp` is currently tested before `build_tiff`.

So this PR rearranges items so that the dependencies are tested by themselves first.