### PR TITLE
Updated libpng to 1.6.37

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -13,7 +13,7 @@ OPENBLAS_LIB_URL="https://anaconda.org/multibuild-wheels-staging/openblas-libs"
 OPENBLAS_VERSION="${OPENBLAS_VERSION:-0.3.10}"
 # We use system zlib by default - see build_new_zlib
 ZLIB_VERSION="${ZLIB_VERSION:-1.2.10}"
-LIBPNG_VERSION="${LIBPNG_VERSION:-1.6.21}"
+LIBPNG_VERSION="${LIBPNG_VERSION:-1.6.37}"
 BZIP2_VERSION="${BZIP2_VERSION:-1.0.7}"
 FREETYPE_VERSION="${FREETYPE_VERSION:-2.11.0}"
 TIFF_VERSION="${TIFF_VERSION:-4.1.0}"


### PR DESCRIPTION
Updated default libpng from 1.6.21 to 1.6.37, to avoid a vulnerability

http://www.libpng.org/pub/png/libpng.html
> libpng versions 1.6.36 and earlier have a use-after-free bug in the simplified libpng API png_image_free(). It has been assigned ID CVE-2019-7317. The vulnerability is fixed in version 1.6.37, released on 15 April 2019.