### PR TITLE
Change default test image for 64-bit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,8 +270,8 @@ Test phase
 Specify the version to test with the ``DOCKER_TEST_IMAGE`` environment
 variable. The default version is dependent on ``PLAT``:
 
-* ``matthewbrett/trusty:64``, for ``x86_64``
-* ``matthewbrett/trusty:32`` for ``i686``
+* ``multibuild/focal_x86_64``, for ``x86_64``
+* ``matthewbrett/trusty:32`` for ``i686`` (Yes, an older image for 32-bit)
 * ``multibuild/xenial_arm64v8`` for ``aarch64``
 * ``multibuild/xenial_ppc64le`` for ``ppc64le``
 * ``mutlibuild/xenial_s390x`` for ``s390x``

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -116,7 +116,11 @@ function install_run {
     local plat=${1:-${PLAT:-x86_64}}
     if [ -z "$DOCKER_TEST_IMAGE" ]; then
         local bitness=$([ "$plat" == i686 ] && echo 32 || echo 64)
-        local docker_image="matthewbrett/trusty:$bitness"
+        if [ "$bitness" == "32" ]; then
+            local docker_image="matthewbrett/trusty:$bitness"
+        else
+            local docker_image="multibuild/focal_x86_64"
+        fi
     else
         # aarch64 is called arm64v8 in Ubuntu
         local plat_subst=$([ "$plat" == aarch64 ] && echo arm64v8 || echo $plat)


### PR DESCRIPTION
Use Focal test image by default.

Stick to Trusty for 32-bit (we don't have a 32-bit Focal image).