### PR TITLE
Updating OSX py3.10 installer

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -19,7 +19,7 @@ LATEST_3p6=3.6.8
 LATEST_3p7=3.7.9
 LATEST_3p8=3.8.10
 LATEST_3p9=3.9.7
-LATEST_3p10=3.10.0
+LATEST_3p10=3.10.0post2
 
 
 function check_python {


### PR DESCRIPTION
[macOS 64-bit universal2 ](https://www.python.org/downloads/release/python-3100/) installer has changed the URL.

