### PR TITLE
WIP, MAINT: selective OSX deploy target

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -486,7 +486,11 @@ function macos_arm64_cross_build_setup {
     export FC=$FC_ARM64
     export F90=${F90_ARM64:-${FC}}
     export F77=${F77_ARM64:-${FC}}
-    export MACOSX_DEPLOYMENT_TARGET="11.0"
+    # we only overwrite the MACOSX_DEPLOYMENT_TARGET
+    # for versions starting with 10.x
+    if [[ $MACOSX_DEPLOYMENT_TARGET =~ "10." ]]; then
+        export MACOSX_DEPLOYMENT_TARGET="11.0"
+    fi
     export CROSS_COMPILING=1
     export LDFLAGS+=" -arch arm64 -L$BUILD_PREFIX/lib -Wl,-rpath,$BUILD_PREFIX/lib ${FC_ARM64_LDFLAGS:-}"
     # This would automatically let autoconf know that we are cross compiling for arm64 darwin

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -489,6 +489,8 @@ function macos_arm64_cross_build_setup {
     # we only overwrite the MACOSX_DEPLOYMENT_TARGET
     # for versions starting with 10.x
     if [[ ${MACOSX_DEPLOYMENT_TARGET:-10.0} =~ "10." ]]; then
+        # version should be at least 11.0, with the option
+        # to override if version > 11.0 specified
         export MACOSX_DEPLOYMENT_TARGET="11.0"
     fi
     export CROSS_COMPILING=1

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -488,7 +488,7 @@ function macos_arm64_cross_build_setup {
     export F77=${F77_ARM64:-${FC}}
     # we only overwrite the MACOSX_DEPLOYMENT_TARGET
     # for versions starting with 10.x
-    if [[ $MACOSX_DEPLOYMENT_TARGET =~ "10." ]]; then
+    if [[ ${MACOSX_DEPLOYMENT_TARGET:-10.0} =~ "10." ]]; then
         export MACOSX_DEPLOYMENT_TARGET="11.0"
     fi
     export CROSS_COMPILING=1


### PR DESCRIPTION
* only overwrite MACOSX_DEPLOYMENT_TARGET environment
variable when it contains the "10.x" version string

* motivation is to allow sensibel overrides as in:
https://github.com/MacPython/scipy-wheels/pull/150

* note that I have not tested this yet, but am open
to making revisions of course

cc @isuruf @rgommers