### PR TITLE
Skip configure in giflib if version >= 5.1.5

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -228,7 +228,24 @@ function build_lcms2 {
 }
 
 function build_giflib {
-    build_simple giflib $GIFLIB_VERSION https://downloads.sourceforge.net/project/giflib
+    local name=giflib
+    local version=$GIFLIB_VERSION
+    local url=https://downloads.sourceforge.net/project/giflib
+    if [ $(lex_ver $GIFLIB_VERSION) -lt $(lex_ver 5.1.5) ]; then
+        build_simple $name $version $url
+    else
+        local ext=tar.gz
+        if [ -e "${name}-stamp" ]; then
+            return
+        fi
+        local name_version="${name}-${version}"
+        local archive=${name_version}.${ext}
+        fetch_unpack $url/$archive
+        (cd $name_version \
+            && make -j4 \
+            && make install)
+        touch "${name}-stamp"
+    fi
 }
 
 function build_xz {


### PR DESCRIPTION
giflib >= 5.1.5 no longer has a 'configure' file.

This is noted in https://github.com/nesbox/giflib/blob/master/NEWS
> The horrible old autoconf build system has been removed with extreme prejudice. 
> You now build this simply by running "make" from the top-level directory.

So if the giflib verison is >= 5.1.5, this PR runs a modified version of build_simple that skips the `./configure` step.