### PR TITLE
Fetch tags in clean_code

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -284,7 +284,7 @@ function clean_code {
     # to determine the version.  Give submodule proper git directory
     fill_submodule "$repo_dir"
     (cd $repo_dir \
-        && git fetch origin \
+        && git fetch origin --tags \
         && git checkout $build_commit \
         && git clean -fxd \
         && git reset --hard \


### PR DESCRIPTION
When building wheels, it wasn't able to find the latest tags: https://github.com/pyproj4/pyproj-wheels/runs/4961483736?check_suite_focus=true

This fixed the issue.