### PR TITLE
Added build_libjpeg_turbo

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -159,6 +159,18 @@ function build_jpeg {
     touch jpeg-stamp
 }
 
+function build_libjpeg_turbo {
+    if [ -e jpeg-stamp ]; then return; fi
+    local cmake=$(get_modern_cmake)
+    fetch_unpack https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-${JPEGTURBO_VERSION}.tar.gz
+    (cd libjpeg-turbo-${JPEGTURBO_VERSION} \
+        && $cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=/usr/local/lib . \
+        && make install)
+
+    # Prevent build_jpeg
+    touch jpeg-stamp
+}
+
 function build_libpng {
     build_zlib
     build_simple libpng $LIBPNG_VERSION https://download.sourceforge.net/libpng

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -61,6 +61,8 @@ if [ -z "$IS_MACOS" ]; then
 fi
 suppress build_new_zlib
 suppress build_hdf5
+rm jpeg-stamp
+suppress build_libjpeg_turbo
 suppress get_modern_cmake
 
 [ ${MB_PYTHON_VERSION+x} ] || ingest "\$MB_PYTHON_VERSION is not set"


### PR DESCRIPTION
This PR suggests adding `build_libjpeg_turbo`.

This is an alternative to libjpeg, so rather than touching "jpegturbo-stamp" or similar, it touches "jpeg-stamp", just as `build_jpeg` does. This means that if a user ran `build_libjpeg_turbo`, and then `build_tiff` (which internally calls `build_jpeg`), libjpeg would not be built, because libjpeg turbo was already in place.