### PR TITLE
Fixed installing cmake and wget on Alpine

### DIFF
--- a/configure_build.sh
+++ b/configure_build.sh
@@ -58,8 +58,12 @@ else
         # centos based distro
         yum install -y libtool wget
     elif [ "${MB_PYTHON_VERSION:0:4}" == "pypy" ]; then
-        # centos based distro
-        yum install -y wget
+        if [ -n "$IS_ALPINE" ]; then
+          apk add wget
+        else
+          # centos based distro
+          yum install -y wget
+        fi
     fi
 fi
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -189,7 +189,7 @@ function get_modern_cmake {
     if [ -n "$IS_MACOS" ]; then
         brew install cmake > /dev/null
     elif [ -n "$IS_ALPINE" ]; then
-        apk add cmake
+        apk add cmake > /dev/null
     elif [[ $MB_ML_VER == "_2_24" ]]; then
         # debian:9 based distro
         apt-get install -y cmake


### PR DESCRIPTION
After #430,
- Use apk instead of yum when installing wget in configure_build.sh
- Redirect stdout when installing cmake on Alpine in `get_modern_cmake`, to prevent the stdout from becoming part of the response