### PR TITLE
Updated README after default MB_ML_VER changed in #423

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,7 @@ Build phase
 -----------
 
 Specify the Manylinux version to build for with the ``MB_ML_VER`` environment
-variable. The default version is ``1``.  Versions that are currently valid are:
+variable. The default version is ``2014``.  Versions that are currently valid are:
 
 * ``1`` corresponding to manylinux1 (see `PEP 513 <https://www.python.org/dev/peps/pep-0513>`_).
 * ``2010``  corresponding to manylinux2010 (see `PEP 571 <https://www.python.org/dev/peps/pep-0571>`_).


### PR DESCRIPTION
Updated the README to match the current default.

https://github.com/multi-build/multibuild/blob/a05e8f2eb71304eaf1187a68e36b8ceebf091fb7/common_utils.sh#L27-L28