### PR TITLE
Set relevant MB_ML_VER default for musllinux

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -24,9 +24,6 @@ GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 # with, so it is passed in when calling "docker run" for tests.
 UNICODE_WIDTH=${UNICODE_WIDTH:-32}
 
-# Default Manylinux version
-MB_ML_VER=${MB_ML_VER:-2014}
-
 if [ $(uname) == "Darwin" ]; then
   IS_MACOS=1; IS_OSX=1;
 else
@@ -37,6 +34,10 @@ fi
 
 if [ "$MB_ML_LIBC" == "musllinux" ]; then
   IS_ALPINE=1;
+  MB_ML_VER=${MB_ML_VER:-"_1_1"}
+else
+  # Default Manylinux version
+  MB_ML_VER=${MB_ML_VER:-2014}
 fi
 
 # Work round bug in travis xcode image described at


### PR DESCRIPTION
The MB_ML_VER default is currently 2014.
https://github.com/multi-build/multibuild/blob/a05e8f2eb71304eaf1187a68e36b8ceebf091fb7/common_utils.sh#L27-L28

This is a valid default for manylinux. For musllinux though, "_1_1" would be better.

This PR sets the default depending on whether MB_ML_LIBC is manylinux or musllinux.