### PR TITLE
Updated to Alpine 3.15 test image

### DIFF
--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -142,6 +142,7 @@ function install_run {
         -e CONFIG_PATH="$CONFIG_PATH" \
         -e WHEEL_SDIR="$WHEEL_SDIR" \
         -e MANYLINUX_URL="$MANYLINUX_URL" \
+        -e MB_ML_LIBC="$MB_ML_LIBC" \
         -e TEST_DEPENDS="$TEST_DEPENDS" \
         -v $PWD:/io \
         $docker_image /io/$MULTIBUILD_DIR/docker_test_wrap.sh

--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -120,7 +120,7 @@ function install_run {
     local plat=${1:-${PLAT:-x86_64}}
     if [ -z "$DOCKER_TEST_IMAGE" ]; then
         if [ "$MB_ML_LIBC" == "musllinux" ]; then
-            local docker_image="multibuild/alpine3.14_$plat"
+            local docker_image="multibuild/alpine3.15_$plat"
         else
             local bitness=$([ "$plat" == i686 ] && echo 32 || echo 64)
             if [ "$bitness" == "32" ]; then


### PR DESCRIPTION
After https://github.com/multi-build/docker-images/pull/29, and seen at https://hub.docker.com/r/multibuild/alpine3.15_x86_64, we can now use Alpine 3.15.