### PR TITLE
Use mirror instead of flaky sourceware.org

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -182,7 +182,7 @@ function build_libpng {
 function build_bzip2 {
     if [ -n "$IS_MACOS" ]; then return; fi  # OSX has bzip2 libs already
     if [ -e bzip2-stamp ]; then return; fi
-    fetch_unpack https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz
+    fetch_unpack https://mirrors.kernel.org/sourceware/bzip2/bzip2-${BZIP2_VERSION}.tar.gz
     (cd bzip2-${BZIP2_VERSION} \
         && make -f Makefile-libbz2_so \
         && make install PREFIX=$BUILD_PREFIX)


### PR DESCRIPTION
We had lots of timeouts connecting to https://sourceware.org during yesterday's Pillow release, and just one in a batch of ~25 wheel builds meant the whole 45 min build needed restarting (https://github.com/python-pillow/pillow-wheels/issues/276).

About 8/10 of the failures were sourceware timeouts ([3](https://github.com/python-pillow/pillow-wheels/actions/runs/2075952528) + [7](https://github.com/python-pillow/pillow-wheels/actions/runs/2076994216)).

Sourceware themselves say:

> These sites mirror the free software ftp directory directly. The master sourceware.org server itself is usually overloaded.

https://sourceware.org/mirrors.html

So let's use a mirror here too.
