### PR TITLE
Replace aarch64 with arm64v8 for default focal DOCKER_TEST_IMAGE

### DIFF
--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -124,7 +124,7 @@ function install_run {
         elif [ "$plat" == i686 ]; then
             local docker_image="matthewbrett/trusty:32"
         else
-            local docker_image="multibuild/focal_$plat"
+            local docker_image="multibuild/focal_{PLAT}"
         fi
     else
         local docker_image="$DOCKER_TEST_IMAGE"


### PR DESCRIPTION
When `install_run` replaces "aarch64" with "arm64v8", it should do so when `$plat` matches, not just `$PLAT`.

This then includes the scenario where the user passes in the value as the first argument to `install_run`, not just using the global `$PLAT`.