### PR TITLE
Update 3.11.0 to RC1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,8 @@ The Travis CI scripts are designed to build *and test*:
   where `X` is any valid Manylinux version: `1`, `2010`, `2014`, `_2_24` or `_2_28`.
 * 32-bit ``manylinuxX_i686`` wheels, both narrow and wide Unicode builds
 
-You can currently build and test against Pythons 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 and 3.10.
+You can currently build and test against Pythons 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10
+and 3.11.
 
 The small innovation here is that you can test against Linux 32-bit builds, both
 wide and narrow Unicode Python 2 builds, which was not easy on the default
@@ -143,7 +144,8 @@ The AppVeyor setup is designed to build *and test*:
 * 64-bit Windows ``win_amd64`` wheels
 * 32-bit Windows ``win32`` wheels
 
-You can currently build and test against Pythons 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 and 3.10.
+You can currently build and test against Pythons 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10
+and 3.11.
 
 *****************
 How does it work?

--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -10,7 +10,7 @@ MACPYTHON_URL=https://www.python.org/ftp/python
 MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
 WORKING_SDIR=working
 
-# As of 2 Aug 2022 - latest Python of each version with binary download
+# As of 1 Sep 2022 - latest Python of each version with binary download
 # available.
 # See: https://www.python.org/downloads/macos/
 LATEST_2p7=2.7.18
@@ -20,7 +20,7 @@ LATEST_3p7=3.7.9
 LATEST_3p8=3.8.10
 LATEST_3p9=3.9.13
 LATEST_3p10=3.10.6
-LATEST_3p11=3.11.0b5
+LATEST_3p11=3.11.0rc1
 
 
 function check_python {


### PR DESCRIPTION
RC1 is the latest with RC2 due on Monday: https://peps.python.org/pep-0664/

And add 3.11 to the README.