### PR TITLE
Fix pcre download

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -424,6 +424,7 @@ function build_netcdf {
         && make -j4 \
         && make install)
     touch netcdf-stamp
+}
 
 function build_pcre {
     build_simple pcre $PCRE_VERSION https://sourceforge.net/projects/pcre/files/pcre/${PCRE_VERSION}

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -424,10 +424,9 @@ function build_netcdf {
         && make -j4 \
         && make install)
     touch netcdf-stamp
-}
 
 function build_pcre {
-    build_simple pcre $PCRE_VERSION https://ftp.pcre.org/pub/pcre
+    build_simple pcre $PCRE_VERSION https://sourceforge.net/projects/pcre/files/pcre/${PCRE_VERSION}
 }
 
 function build_swig {


### PR DESCRIPTION
As stated in https://pcre.org/, PCRE has been moved to sourceforge and the old FTP is no longer available.