### PR TITLE
universal2 build improvements

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -511,7 +511,7 @@ function fuse_macos_intel_arm64 {
     mkdir -p tmp_fused_wheelhouse
     for whl in $wheelhouse/*.whl; do
        if [[ "$whl" == *macosx_${py_osx_ver}_x86_64.whl ]]; then
-           whl_base=$(echo $whl | rev | cut -c 23- | rev)
+           whl_base=$(sed "s/macosx_${py_osx_ver}_x86_64.whl//" <<< $whl)
            if [[ -f "${whl_base}macosx_11_0_arm64.whl" ]]; then
                delocate-fuse $whl "${whl_base}macosx_11_0_arm64.whl" -w tmp_fused_wheelhouse
                mv tmp_fused_wheelhouse/$(basename $whl) $wheelhouse/$(basename ${whl_base})macosx_${py_osx_ver}_universal2.whl


### PR DESCRIPTION
Two suggested changes when building universal2 wheels.

1. Instead of presuming the length of the string to replace in the following code, use `sed`. This will allow `$py_osx_ver` to vary in length.
https://github.com/multi-build/multibuild/blob/2e10577a0c2fd2b0d36b3d96dc5c273d2df20698/osx_utils.sh#L513-L514

2. When building for universal2 on x86-64, run the cross build first and then the native build. This will mean that the more natural native variables are in place when the code is finished, for anything that might run afterwards.