### PR TITLE
Upgrade setuptools in lint build

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install --upgrade pip wheel
+      - run: pip install --upgrade pip wheel setuptools
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
                          flake8-comprehensions isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101 .  # B101 is assert statements


### PR DESCRIPTION
lint_python is currently failing for devel - https://github.com/multi-build/multibuild/actions/runs/4058339482

Upgrading setuptools fixes it.