### PR TITLE
Use MACOSX_DEPLOYMENT_TARGET when searching for wheels to fuse

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -507,7 +507,7 @@ function macos_arm64_native_build_setup {
 
 function fuse_macos_intel_arm64 {
     local wheelhouse=$(abspath ${WHEEL_SDIR:-wheelhouse})
-    local py_osx_ver=$(echo ${MB_PYTHON_OSX_VER} | sed "s/\./_/g")
+    local py_osx_ver=$(echo ${MACOSX_DEPLOYMENT_TARGET} | sed "s/\./_/g")
     mkdir -p tmp_fused_wheelhouse
     for whl in $wheelhouse/*.whl; do
        if [[ "$whl" == *macosx_${py_osx_ver}_x86_64.whl ]]; then


### PR DESCRIPTION
When searching for wheels to fuse, multibuild currently uses `MB_PYTHON_OSX_VER` to search for the wheels that were built.

https://github.com/multi-build/multibuild/blob/c0a319a5358538b1bf561908f740b24999c76370/osx_utils.sh#L508-L516

I think this should be `MACOSX_DEPLOYMENT_TARGET` instead.

To demonstrate, I've created a simplified branch of pillow-wheels - https://github.com/radarhere/pillow-wheels/tree/demo.
All it does to set the macOS version for the wheels is [`export MACOSX_DEPLOYMENT_TARGET="10.10"`](https://github.com/radarhere/pillow-wheels/blob/41818530935e7fa165f4fdc288d79da95c3b2130/.github/workflows/build.sh#L1)

Without this change, there is [no universal2 wheel at the end of a build.](https://github.com/radarhere/pillow-wheels/actions/runs/4084005956/jobs/7040196343#step:4:1337) [With](https://github.com/radarhere/pillow-wheels/commit/41818530935e7fa165f4fdc288d79da95c3b2130) this change, [there is.](https://github.com/radarhere/pillow-wheels/actions/runs/4084007709/jobs/7040200049#step:4:1263)