### PR TITLE
Ensure wheel is installed before import

### DIFF
--- a/common_utils.sh
+++ b/common_utils.sh
@@ -444,7 +444,7 @@ function install_wheel {
     check_python
     check_pip
 
-    $PIP_CMD install packaging
+    $PIP_CMD install packaging wheel
     local supported_wheels=$($PYTHON_EXE $MULTIBUILD_DIR/supported_wheels.py $wheelhouse/*.whl)
     if [ -z "$supported_wheels" ]; then
         echo "ERROR: no supported wheels found"


### PR DESCRIPTION
`install_wheel` calls supported_wheels.py
https://github.com/multi-build/multibuild/blob/07f10c3439d6e892c030efcc0884b608679766c2/common_utils.sh#L447-L448
and supported_wheels.py imports `wheel`
https://github.com/multi-build/multibuild/blob/07f10c3439d6e892c030efcc0884b608679766c2/supported_wheels.py#L11-L15

However, in Python 3.12 I get
```
  Traceback (most recent call last):
    File "/io/multibuild/supported_wheels.py", line 12, in <module>
      from wheel.install import WHEEL_INFO_RE as wheel_matcher
  ModuleNotFoundError: No module named 'wheel'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/io/multibuild/supported_wheels.py", line 14, in <module>
      from wheel.wheelfile import WHEEL_INFO_RE
  ModuleNotFoundError: No module named 'wheel'
```

I expect this is related to https://docs.python.org/3.12/whatsnew/3.12.html#removed

This PR adds `wheel` to that earliest install command.