### PR TITLE
Changed repo_dir variable to be uppercase

### DIFF
--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -94,7 +94,7 @@ function build_multilinux {
         -e MANYLINUX_URL="$MANYLINUX_URL" \
         -e BUILD_DEPENDS="$BUILD_DEPENDS" \
         -e USE_CCACHE="$USE_CCACHE" \
-        -e REPO_DIR="$repo_dir" \
+        -e REPO_DIR="$REPO_DIR" \
         -e PLAT="$PLAT" \
         -e MB_ML_VER="$MB_ML_VER" \
         -e MB_ML_LIBC="$libc" \


### PR DESCRIPTION
In `build_multilinux`, I would expect `repo_dir` to be uppercase, referring to the environment variable, rather than lowercase, referring to a non-existent local variable.
https://github.com/multi-build/multibuild/blob/4eb855680308fd279357896dfe0afe59e5c307fa/travis_linux_steps.sh#L66-L104

A local `repo_dir` variable was originally added in https://github.com/multi-build/multibuild/commit/09555a6b74133c3f580def75a874d4182643c2d9, but was effectively removed in https://github.com/multi-build/multibuild/commit/3998141