### PR TITLE
Only add wrapped archflags if not already present.

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -466,7 +466,7 @@ function macos_intel_native_build_setup {
     export _PYTHON_HOST_PLATFORM="macosx-${MB_PYTHON_OSX_VER}-x86_64"
     export CFLAGS+=" -arch x86_64"
     export CXXFLAGS+=" -arch x86_64"
-    export ARCHFLAGS+=" -arch x86_64"
+    [[ $ARCHFLAGS =~ "-arch x86_64" ]] || export ARCHFLAGS+=" -arch x86_64"
     export CPPFLAGS+=" -arch x86_64"
     export LDFLAGS+=" -arch x86_64"
 }
@@ -487,7 +487,7 @@ function macos_arm64_cross_build_setup {
     export CFLAGS+=" -arch arm64"
     export CXXFLAGS+=" -arch arm64"
     export CPPFLAGS+=" -arch arm64"
-    export ARCHFLAGS+=" -arch arm64"
+    [[ $ARCHFLAGS =~ "-arch arm64" ]] || export ARCHFLAGS+=" -arch arm64"
     export FCFLAGS+=" -arch arm64"
     export FC=$FC_ARM64
     export F90=${F90_ARM64:-${FC}}


### PR DESCRIPTION
meson-python does not like duplicate ARCHFLAGS values, and will error
with output such as:

```
('\x1b[31m',)meson-python: error: Multi-architecture builds are not
supported but $ARCHFLAGS='-arch x86_64 -arch x86_64'
[end of output]
```

https://github.com/nipy/nipy-wheels/actions/runs/6805528295/job/18505232990#step:4:164
at time of writing.