### PR TITLE
MRG: Add tomli, ensure virtualenv

### DIFF
--- a/travis_linux_steps.sh
+++ b/travis_linux_steps.sh
@@ -19,10 +19,13 @@ MB_PYTHON_VERSION=${MB_PYTHON_VERSION:-$TRAVIS_PYTHON_VERSION}
 
 function before_install {
     # Install a virtualenv to work in.
+    # Virtualenv package may not be installed on host Python.
+    python -m pip install virtualenv
     virtualenv --python=$PYTHON_EXE venv
     source venv/bin/activate
     python --version # just to check
-    pip install --upgrade pip wheel
+    # Tomli for pyproject.toml parsing, to get dependencies.
+    pip install --upgrade pip wheel tomli
 }
 
 function build_wheel {

--- a/travis_osx_steps.sh
+++ b/travis_osx_steps.sh
@@ -39,7 +39,8 @@ function before_install {
 
     get_macpython_environment $MB_PYTHON_VERSION venv
     source venv/bin/activate
-    pip install --upgrade pip wheel
+    # Tomli for pyproject.toml parsing, to get dependencies.
+    pip install --upgrade pip wheel tomli
 }
 
 # build_wheel function defined in common_utils (via osx_utils)

--- a/travis_steps.sh
+++ b/travis_steps.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Despite the name, this file is not specific to Travis-CI.
+# It sets up the local environment for wheel building and testing.
+# For Mac, configure xcode, and set up before_install and other
+# functions to wrap builds.
+# For linux, set up before_install to work in virtualenv, and set up wrapping
+# to run build and tests in docker containers.
 
 WHEEL_SDIR=${WHEEL_SDIR:-wheelhouse}
 


### PR DESCRIPTION
We seem to need virtualenv on the Github runners - ensure.

Install tomli by default on local python, to allow pyproject.toml parsers to
fetch requirements etc.