### PR TITLE
Add Python 3.13 release candidate 1

### DIFF
--- a/osx_utils.sh
+++ b/osx_utils.sh
@@ -22,6 +22,7 @@ LATEST_3p9=3.9.13
 LATEST_3p10=3.10.11
 LATEST_3p11=3.11.6
 LATEST_3p12=3.12.0
+LATEST_3p13=3.13.0rc1
 
 
 function check_python {
@@ -80,6 +81,8 @@ function fill_pyver {
         echo $LATEST_2p7
     elif [ $ver == 3 ] || [ $ver == "3.12" ]; then
         echo $LATEST_3p12
+    elif [ $ver == "3.13" ]; then
+        echo $LATEST_3p13
     elif [ $ver == "3.11" ]; then
         echo $LATEST_3p11
     elif [ $ver == "3.10" ]; then

--- a/tests/test_fill_pyver.sh
+++ b/tests/test_fill_pyver.sh
@@ -3,6 +3,8 @@
 [ "$(fill_pyver 2.7)" == $LATEST_2p7 ] || ingest
 [ "$(fill_pyver 2.7.8)" == "2.7.8" ] || ingest
 [ "$(fill_pyver 3)" == $LATEST_3p12 ] || ingest
+[ "$(fill_pyver 3.13)" == $LATEST_3p13 ] || ingest
+[ "$(fill_pyver 3.13.0)" == "3.13.0" ] || ingest
 [ "$(fill_pyver 3.12)" == $LATEST_3p12 ] || ingest
 [ "$(fill_pyver 3.12.0)" == "3.12.0" ] || ingest
 [ "$(fill_pyver 3.11)" == $LATEST_3p11 ] || ingest


### PR DESCRIPTION
Python 3.13.0 is now in release candidate phase, which makes it ABI stable. This PR adds the [first release candidate](https://pythoninsider.blogspot.com/2024/08/python-3130-release-candidate-1-released.html).

This PR follows the changes in last year's PR:
- https://github.com/multi-build/multibuild/pull/505.

**Edit:** And, like last year, an update to the docker-images:
- https://github.com/multi-build/docker-images/pull/47