### PR TITLE
remove noisy inaccurate safety check from linting

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,7 +10,7 @@ jobs:
           python-version: '3.12'
       - run: pip install --upgrade pip wheel setuptools
       - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
-                         flake8-comprehensions isort mypy pytest pyupgrade safety
+                         flake8-comprehensions isort mypy pytest pyupgrade
       - run: bandit --recursive --skip B101 .  # B101 is assert statements
       - run: black --check . || true
       - run: codespell --ignore-words-list="commend"  # --skip="*.css,*.js,*.lock"
@@ -22,4 +22,3 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: pytest . || pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
-      - run: safety check


### PR DESCRIPTION
As noted in #499 and #497, safety has very limited value. It is now detecting a disputed vulnerability in one of its own dependencies. It is time to disable it.