### PR TITLE
Honor BUILD_PREFIX in giflib builds.

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -260,7 +260,7 @@ function build_giflib {
         fetch_unpack $url/$archive
         (cd $name_version \
             && make -j4 \
-            && make install)
+            && make install PREFIX=$BUILD_PREFIX)
         touch "${name}-stamp"
     fi
 }


### PR DESCRIPTION
The build recipe for `giflib` will unconditionally install into `/usr/local/bin`,  the default installation prefix for the "makefile only" giflib project. 

This PR modifies the `giflib` build recipe to use the value of `BUILD_PREFIX`, matching the behavior of other recipes.