### PR TITLE
Ensure cmake-compiled libraries aren't installed with an rpath

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -344,12 +344,6 @@ function build_blosc {
     (cd c-blosc-${BLOSC_VERSION} \
         && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
-    if [ -n "$IS_MACOS" ]; then
-        # Fix blosc library id bug
-        for lib in $(ls ${BUILD_PREFIX}/lib/libblosc*.dylib); do
-            install_name_tool -id $lib $lib
-        done
-    fi
     touch blosc-stamp
 }
 

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -167,7 +167,7 @@ function build_libjpeg_turbo {
     local cmake=$(get_modern_cmake)
     fetch_unpack https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-${JPEGTURBO_VERSION}.tar.gz
     (cd libjpeg-turbo-${JPEGTURBO_VERSION} \
-        && $cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib . \
+        && $cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
 
     # Prevent build_jpeg
@@ -234,7 +234,7 @@ function build_openjpeg {
     fi
     local out_dir=$(fetch_unpack https://github.com/uclouvain/openjpeg/archive/${archive_prefix}${OPENJPEG_VERSION}.tar.gz)
     (cd $out_dir \
-        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX . \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
     touch openjpeg-stamp
 }
@@ -342,7 +342,7 @@ function build_blosc {
     local cmake=$(get_modern_cmake)
     fetch_unpack https://github.com/Blosc/c-blosc/archive/v${BLOSC_VERSION}.tar.gz
     (cd c-blosc-${BLOSC_VERSION} \
-        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX . \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
     if [ -n "$IS_MACOS" ]; then
         # Fix blosc library id bug


### PR DESCRIPTION
The default behavior of cmake is to build and install a library with the library's install_name set to `@rpath/libname.dylib`. While this is a good default when the library is being used in an executable, it's a problem on macOS when the library is being used as a dependency in a wheel, because the `@rpath` can't be resolved as part of the delocate process.

Libraries build with autotools/configure (or manually constructed makefiles) aren't affected by this; their default install name is the full install path unless specifically configured with an installation name. 

The libblosc build instruction already included a workaround to explicitly set the library identifiers; it's possible to replace that workaround with an explicit cmake configuration.

In addition, the `CMAKE_INSTALL_LIBDIR` value used for libjpeg-turbo is redundant, as the `/lib` suffix will be implied from the `CMAKE_INSTALL_PREFIX` value.