### PR TITLE
Format and lint Python code with ruff

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - run: pipx run codespell --ignore-words-list="commend"
       - run: pip install mypy pytest ruff
       - run: ruff format --check --config "format.quote-style = 'single'"
-      - run: ruff check --output-format=github --select=ALL --ignore=Q000
+      - run: ruff check --output-format=github --select=ALL --ignore=D203,D212,Q000
       - run: pip install -r requirements.txt || pip install --editable . || true
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,18 +7,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - run: pip install --upgrade pip wheel setuptools
-      - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
-                         flake8-comprehensions isort mypy pytest pyupgrade
-      - run: bandit --recursive --skip B101 .  # B101 is assert statements
-      - run: black --check . || true
-      - run: codespell --ignore-words-list="commend"  # --skip="*.css,*.js,*.lock"
-      - run: flake8 . --count --max-complexity=10 --max-line-length=88
-                      --show-source --statistics
-      - run: isort --check-only --profile black .
+      - run: pipx run codespell --ignore-words-list="commend"
+      - run: pip install mypy pytest ruff
+      - run: ruff format --check --config "format.quote-style = 'single'"
+      - run: ruff check --output-format=github --select=ALL --ignore=Q000
       - run: pip install -r requirements.txt || pip install --editable . || true
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: pytest . || pytest --doctest-modules . || true
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true

--- a/supported_wheels.py
+++ b/supported_wheels.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python
-"""  Filter out wheel filenames not supported on this platform
-"""
-from __future__ import print_function
+"""Filter out wheel filenames not supported on this platform."""
+
+from __future__ import annotations
 
 import sys
 from os.path import basename
+from typing import TYPE_CHECKING
 
 from packaging.tags import sys_tags
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 try:
-    from wheel.install import WHEEL_INFO_RE as wheel_matcher
+    from wheel.install import WHEEL_INFO_RE as wheel_matcher  # noqa: N811
 except ImportError:  # As of Wheel 0.32.0
     from wheel.wheelfile import WHEEL_INFO_RE
+
     wheel_matcher = WHEEL_INFO_RE.match
 
 
-def tags_for(fname):
-    # Copied from WheelFile code
-    parsed_filename = wheel_matcher(basename(fname))
+def tags_for(fname: str) -> Iterator[tuple[str, str, str]]:
+    """Copied from WheelFile code."""  # noqa: D401
+    parsed_filename = wheel_matcher(basename(fname))  # noqa: PTH119
     tags = parsed_filename.groupdict()
     for pyver in tags['pyver'].split('.'):
         for abi in tags['abi'].split('.'):
@@ -25,14 +30,13 @@ def tags_for(fname):
                 yield (pyver, abi, plat)
 
 
-def main():
-    supported = {
-        (tag.interpreter, tag.abi, tag.platform) for tag in sys_tags()
-    }
+def main() -> None:
+    """Print filenames of all supported wheels."""
+    supported = {(tag.interpreter, tag.abi, tag.platform) for tag in sys_tags()}
     for fname in sys.argv[1:]:
         tags = set(tags_for(fname))
         if supported.intersection(tags):
-            print(fname)
+            print(fname)  # noqa: T201
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replace bandit, black, flake8, flake8-2020, flake8-bugbear, flake8-comprehensions, isort, and pyupgrade with ruff.

https://docs.astral.sh/ruff
> Ruff can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [Black](https://github.com/psf/black), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [pyupgrade](https://pypi.org/project/pyupgrade/), [autoflake](https://pypi.org/project/autoflake/), and more, all while executing tens or hundreds of times faster than any individual tool.