### PR TITLE
Restored `CMAKE_INSTALL_LIBDIR` to libjpeg-turbo

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -167,7 +167,7 @@ function build_libjpeg_turbo {
     local cmake=$(get_modern_cmake)
     fetch_unpack https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-${JPEGTURBO_VERSION}.tar.gz
     (cd libjpeg-turbo-${JPEGTURBO_VERSION} \
-        && $cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && $cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
 
     # Prevent build_jpeg


### PR DESCRIPTION
#531 stated that
> the `CMAKE_INSTALL_LIBDIR` value used for libjpeg-turbo is redundant, as the `/lib` suffix will be implied from the `CMAKE_INSTALL_PREFIX` value.

However, testing the [updated multibuild with Pillow](https://github.com/radarhere/Pillow/commit/2ae0b1c4d15c19d297dd45ba12a66a1734d07c7a), I find that [a job starts failing](https://github.com/radarhere/Pillow/actions/runs/11479693993/job/31946521238).
If I [restore `CMAKE_INSTALL_LIBDIR`](https://github.com/radarhere/multibuild/commit/654dbebc3a5a8173e4f391ed50b17ed69c8284a6) and [test that](https://github.com/radarhere/Pillow/commit/58aa5f202f0e05481cc5d28dba7da3f5d8e0d337), the job [passes.](https://github.com/radarhere/Pillow/actions/runs/11479708265/job/31946563482)

If the only reason for removing the flag was that it is redundant and makes no difference, then I think I've demonstrated otherwise and would suggest it be restored.