### PR TITLE
Set LIBDIR for remaining cmake-built libraries.

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -234,7 +234,7 @@ function build_openjpeg {
     fi
     local out_dir=$(fetch_unpack https://github.com/uclouvain/openjpeg/archive/${archive_prefix}${OPENJPEG_VERSION}.tar.gz)
     (cd $out_dir \
-        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
     touch openjpeg-stamp
 }
@@ -342,7 +342,7 @@ function build_blosc {
     local cmake=$(get_modern_cmake)
     fetch_unpack https://github.com/Blosc/c-blosc/archive/v${BLOSC_VERSION}.tar.gz
     (cd c-blosc-${BLOSC_VERSION} \
-        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
         && make install)
     touch blosc-stamp
 }


### PR DESCRIPTION
#531 removed the `CMAKE_INSTALL_LIBDIR` configuration from libjpeg-turbo on the basis that it appeared to be redundant. 

#537 restored that flag, after it became clear that it *isn't* redundant - on any platform that uses the `lib64` convention, `CMAKE_INSTALL_LIBDIR` is needed

In the discussion on #537, I speculated that it might be advisable to add the same flag to the other cmake libraries. It turns out I was right - if you set `CMAKE_INSTALL_LIB_NAME` and *don't* set `CMAKE_INSTALL_LIBDIR`, you end up installing the library into `lib64`, requiring a manual extra step to move the library; and additional complications when the linked library references other libraries in lib64. This became apparent during testing on python-pillow#8497, because openjpeg libraries weren't lining up without additional post-build steps.

This adds the `CMAKE_INSTALL_LIBDIR` configuration to openjpeg and blosc.