### PR TITLE
Added cmake-stamp

### DIFF
--- a/library_builders.sh
+++ b/library_builders.sh
@@ -200,20 +200,29 @@ function get_modern_cmake {
     # Install cmake >= 2.8
     local cmake=cmake
     if [ -n "$IS_MACOS" ]; then
-        brew install cmake > /dev/null
+        if [ ! -e cmake-stamp ]; then
+            brew install cmake > /dev/null
+        fi
     elif [ -n "$IS_ALPINE" ]; then
-        apk add cmake > /dev/null
+        if [ ! -e cmake-stamp ]; then
+            apk add cmake > /dev/null
+        fi
     elif [[ $MB_ML_VER == "_2_24" ]]; then
         # debian:9 based distro
-        apt-get install -y cmake
+        if [ ! -e cmake-stamp ]; then
+            apt-get install -y cmake
+        fi
     else
         if [ "`yum search cmake | grep ^cmake28\.`" ]; then
             cmake=cmake28
         fi
         # centos based distro
-        yum_install $cmake > /dev/null
+        if [ ! -e cmake-stamp ]; then
+            yum_install $cmake > /dev/null
+        fi
     fi
     echo $cmake
+    touch cmake-stamp
 }
 
 function get_cmake {


### PR DESCRIPTION
All `build_*` functions in [library_builders.sh](https://github.com/multi-build/multibuild/blob/devel/library_builders.sh) create a `*-stamp` file, to prevent the function from being run more than once. For example,

https://github.com/multi-build/multibuild/blob/9a9d1275f025f737cdaa3c451ba07129dd95f361/library_builders.sh#L155-L163

This PR suggests adding that feature to `get_modern_cmake` as well. It is slightly different - all of the code within should not be skipped on subsequent calls, as `get_modern_cmake` does echo a result - but the install commands can be skipped.