### PR TITLE
Add modifications to support cross-platform builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,15 +2,19 @@ downloads/
 archives/
 *.orig
 *.swp
+venv*/
+.venv/
 
 # lib_check downloads these
 *-stamp
+arch_tmp/
 arb*/
 bzip2*/
 cfitsio/
 flex*/
 freetype*/
 giflib*/
+harfbuzz*/
 hdf5*/
 jpeg*/
 lcms2*/

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -290,11 +290,11 @@ function fetch_unpack {
         rsync --delete -ah * ..)
 
     # If a patch exists, apply it
-    if [ -e "${PATCH_DIR}/${name}-${version}.patch" ]; then
+    if [ -e "$(pwd)/${PATCH_DIR}/${archive_fname}.patch" ]; then
         # The arch_tmp folder will contain the name of folder that was just
         # unpacked from the archive. Apply the patch in that directory.
         local package_dir=$(ls -1c arch_tmp)
-        patch --force -i "${PATCH_DIR}/${name}-${version}.patch" -d $package_dir
+        patch --force -i "$(pwd)/${PATCH_DIR}/${archive_fname}.patch" -d $package_dir
     fi
 }
 

--- a/common_utils.sh
+++ b/common_utils.sh
@@ -288,6 +288,14 @@ function fetch_unpack {
         untar ../$out_archive && \
         ls -1d * &&
         rsync --delete -ah * ..)
+
+    # If a patch exists, apply it
+    if [ -e "${PATCH_DIR}/${name}-${version}.patch" ]; then
+        # The arch_tmp folder will contain the name of folder that was just
+        # unpacked from the archive. Apply the patch in that directory.
+        local package_dir=$(ls -1c arch_tmp)
+        patch --force -i "${PATCH_DIR}/${name}-${version}.patch" -d $package_dir
+    fi
 }
 
 function clean_code {

--- a/library_builders.sh
+++ b/library_builders.sh
@@ -68,7 +68,7 @@ function build_simple {
     local archive=${name_version}.${ext}
     fetch_unpack $url/$archive
     (cd $name_version \
-        && ./configure --prefix=$BUILD_PREFIX $configure_args \
+        && ./configure --prefix=$BUILD_PREFIX $HOST_CONFIGURE_FLAGS $configure_args \
         && make -j4 \
         && make install)
     touch "${name}-stamp"
@@ -85,7 +85,7 @@ function build_github {
     fi
     local out_dir=$(fetch_unpack "https://github.com/${path}/archive/${tag_name}.tar.gz")
     (cd $out_dir \
-        && ./configure --prefix=$BUILD_PREFIX $configure_args \
+        && ./configure --prefix=$BUILD_PREFIX $HOST_CONFIGURE_FLAGS $configure_args \
         && make -j4 \
         && make install)
     touch "${name}-stamp"
@@ -156,7 +156,7 @@ function build_jpeg {
     if [ -e jpeg-stamp ]; then return; fi
     fetch_unpack http://ijg.org/files/jpegsrc.v${JPEG_VERSION}.tar.gz
     (cd jpeg-${JPEG_VERSION} \
-        && ./configure --prefix=$BUILD_PREFIX \
+        && ./configure --prefix=$BUILD_PREFIX $HOST_CONFIGURE_FLAGS \
         && make -j4 \
         && make install)
     touch jpeg-stamp
@@ -167,7 +167,9 @@ function build_libjpeg_turbo {
     local cmake=$(get_modern_cmake)
     fetch_unpack https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-${JPEGTURBO_VERSION}.tar.gz
     (cd libjpeg-turbo-${JPEGTURBO_VERSION} \
-        && $cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && $cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX \
+            -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib \
+            $HOST_CMAKE_FLAGS . \
         && make install)
 
     # Prevent build_jpeg
@@ -197,21 +199,23 @@ function build_tiff {
 }
 
 function get_modern_cmake {
-    # Install cmake >= 2.8
+    # Install cmake >= 2.8 if it isn't installed
     local cmake=cmake
-    if [ -n "$IS_MACOS" ]; then
-        brew install cmake > /dev/null
-    elif [ -n "$IS_ALPINE" ]; then
-        apk add cmake > /dev/null
-    elif [[ $MB_ML_VER == "_2_24" ]]; then
-        # debian:9 based distro
-        apt-get install -y cmake
-    else
-        if [ "`yum search cmake | grep ^cmake28\.`" ]; then
-            cmake=cmake28
+    if ! which $cmake > /dev/null; then
+        if [ -n "$IS_MACOS" ]; then
+            brew install cmake > /dev/null
+        elif [ -n "$IS_ALPINE" ]; then
+            apk add cmake > /dev/null
+        elif [[ $MB_ML_VER == "_2_24" ]]; then
+            # debian:9 based distro
+            apt-get install -y cmake
+        else
+            if [ "`yum search cmake | grep ^cmake28\.`" ]; then
+                cmake=cmake28
+            fi
+            # centos based distro
+            yum_install $cmake > /dev/null
         fi
-        # centos based distro
-        yum_install $cmake > /dev/null
     fi
     echo $cmake
 }
@@ -234,7 +238,7 @@ function build_openjpeg {
     fi
     local out_dir=$(fetch_unpack https://github.com/uclouvain/openjpeg/archive/${archive_prefix}${OPENJPEG_VERSION}.tar.gz)
     (cd $out_dir \
-        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib $HOST_CMAKE_FLAGS . \
         && make install)
     touch openjpeg-stamp
 }
@@ -318,7 +322,7 @@ function build_hdf5 {
     (cd hdf5-$HDF5_VERSION \
         && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BUILD_PREFIX/lib \
         && ./configure --with-szlib=$BUILD_PREFIX --prefix=$BUILD_PREFIX \
-        --enable-threadsafe --enable-unsupported --with-pthread=yes \
+        --enable-threadsafe --enable-unsupported --with-pthread=yes $HOST_CONFIGURE_FLAGS \
         && make -j4 \
         && make install)
     touch hdf5-stamp
@@ -331,7 +335,7 @@ function build_libaec {
     # Note URL will change for each version
     fetch_unpack https://gitlab.dkrz.de/k202009/libaec/uploads/ea0b7d197a950b0c110da8dfdecbb71f/${tar_name}
     (cd $root_name \
-        && ./configure --prefix=$BUILD_PREFIX \
+        && ./configure --prefix=$BUILD_PREFIX $HOST_CONFIGURE_FLAGS \
         && make \
         && make install)
     touch libaec-stamp
@@ -342,7 +346,7 @@ function build_blosc {
     local cmake=$(get_modern_cmake)
     fetch_unpack https://github.com/Blosc/c-blosc/archive/v${BLOSC_VERSION}.tar.gz
     (cd c-blosc-${BLOSC_VERSION} \
-        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib . \
+        && $cmake -DCMAKE_INSTALL_PREFIX=$BUILD_PREFIX -DCMAKE_INSTALL_LIBDIR=$BUILD_PREFIX/lib -DCMAKE_INSTALL_NAME_DIR=$BUILD_PREFIX/lib $HOST_CMAKE_FLAGS . \
         && make install)
     touch blosc-stamp
 }
@@ -355,7 +359,7 @@ function build_lzo {
     if [ -e lzo-stamp ]; then return; fi
     fetch_unpack https://www.oberhumer.com/opensource/lzo/download/lzo-${LZO_VERSION}.tar.gz
     (cd lzo-${LZO_VERSION} \
-        && ./configure --prefix=$BUILD_PREFIX --enable-shared \
+        && ./configure --prefix=$BUILD_PREFIX --enable-shared $HOST_CONFIGURE_FLAGS \
         && make \
         && make install)
     touch lzo-stamp
@@ -415,7 +419,7 @@ function build_netcdf {
     build_curl
     fetch_unpack https://github.com/Unidata/netcdf-c/archive/v${NETCDF_VERSION}.tar.gz
     (cd netcdf-c-${NETCDF_VERSION} \
-        && ./configure --prefix=$BUILD_PREFIX --enable-dap \
+        && ./configure --prefix=$BUILD_PREFIX --enable-dap $HOST_CONFIGURE_FLAGS \
         && make -j4 \
         && make install)
     touch netcdf-stamp
@@ -538,7 +542,7 @@ function build_cfitsio {
         local cfitsio_name_ver=cfitsio${CFITSIO_VERSION}
         fetch_unpack https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/${cfitsio_name_ver}.tar.gz
         (cd cfitsio \
-            && ./configure --prefix=$BUILD_PREFIX \
+            && ./configure --prefix=$BUILD_PREFIX $HOST_CONFIGURE_FLAGS \
             && make shared && make install)
     fi
     touch cfitsio-stamp

--- a/tests/patches/harfbuzz-2.7.4.tar.xz.patch
+++ b/tests/patches/harfbuzz-2.7.4.tar.xz.patch
@@ -1,0 +1,11 @@
+# This is a completely cosmetic patch to validate that source patching works as expected.
+#
+diff -ur harfbuzz-2.7.4-orig/README harfbuzz-2.7.4/README
+--- harfbuzz-2.7.4-orig/README	2024-12-12 09:23:15
++++ harfbuzz-2.7.4/README	2024-12-12 09:23:02
+@@ -13,3 +13,5 @@
+ For test execution, see https://github.com/harfbuzz/harfbuzz/blob/master/TESTING.md
+
+ Documentation: https://harfbuzz.github.io
++
++Harfbuzz has been patched by multibuild

--- a/tests/test_library_builders.sh
+++ b/tests/test_library_builders.sh
@@ -21,8 +21,10 @@ source tests/utils.sh
 
 start_spinner
 
+PATCH_DIR=tests/patches
 fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/2.7.4/harfbuzz-2.7.4.tar.xz
 [ -d harfbuzz-2.7.4 ] || ingest ".tar.xz should have been unpacked"
+[ -n "$(grep 'Harfbuzz has been patched by multibuild' harfbuzz-2.7.4/README)" ] || ingest "Harfbuzz should have been patched"
 
 suppress build_bzip2
 suppress build_openssl


### PR DESCRIPTION
Adds four changes to support cross-platform builds:

1. Adds support for applying patches to downloaded source. If `PATCH_DIR` is defined, and contains a `packagename-version.patch` file that matches the package being unpacked, that patch will be applied to the source tree as part of the `fetch_unpack` step. This is required because some libraries haven't accepted Android and iOS compliance patches (most notably, autotools itself, which has repeatedly ignored/ghosted requests to add support for differentiating iOS simulators from iOS devices).
2. Adds support for a `HOST_CONFIGURE_FLAGS` option that is a blanket "include these flags in the invocation of `./configure`" option. 
3. Adds support for a `HOST_CMAKE_FLAGS` option. The analog of (2), but for cmake. 
4. Disables the install of cmake if it's already installed.

I've been able to use these options, plus some small patches, to build Pillow's dependencies for iOS - e.g.:
```
HOST_CONFIGURE_FLAGS="--disable-shared --enable-static --host=arm64-apple-ios --build=arm64-apple-darwin"
HOST_CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=iOS -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 -DCMAKE_OSX_SYSROOT=<sdk path> -DBUILD_SHARED_LIBS=NO"
```

I've added a test for the patching option; but I haven't added any new tests for the `HOST_CONFIGURE_CFLAGS` and `HOST_CMAKE_FLAGS` options - partly because they're mostly innocuous changes; but mostly because I'm not sure what testing strategy would make sense here. Adding a full iOS build pass seems excessive; but I can't think of an obvious alternative for testing these new capabilities.